### PR TITLE
Adding hugo podtemplate and adding a generic kanikoBuildPush function

### DIFF
--- a/resources/podtemplates/cloud-run.yml
+++ b/resources/podtemplates/cloud-run.yml
@@ -14,5 +14,7 @@ spec:
   volumes:
   - name: gcp-logs
     emptyDir: {}
+  serviceAccount:
+  - cloud-run-sa
   securityContext:
     runAsUser: 1000

--- a/resources/podtemplates/cloud-run.yml
+++ b/resources/podtemplates/cloud-run.yml
@@ -14,7 +14,6 @@ spec:
   volumes:
   - name: gcp-logs
     emptyDir: {}
-  serviceAccount:
-  - cloud-run-sa
+  serviceAccountName: cloud-run-sa
   securityContext:
     runAsUser: 1000

--- a/resources/podtemplates/hugo/pod.yml
+++ b/resources/podtemplates/hugo/pod.yml
@@ -1,0 +1,12 @@
+kind: Pod
+metadata:
+  name: hugo-app
+spec:
+  containers:
+  - name: hugo
+    image: jojomi/hugo:0.58
+    command:
+    - cat
+    tty: true
+  securityContext:
+    runAsUser: 1000

--- a/vars/kanikoBuildPushGeneric.groovy
+++ b/vars/kanikoBuildPushGeneric.groovy
@@ -10,6 +10,8 @@ def call(String imageName, String imageTag = env.BUILD_NUMBER, String gcpProject
       gitShortCommit()
       container(name: 'kaniko', shell: '/busybox/sh') {
         withEnv(['PATH+EXTRA=/busybox:/kaniko']) {
+          sh 'pwd'
+          sh 'ls'
           sh """#!/busybox/sh
             /kaniko/executor -f ${pwd()}/${dockerFile} -c ${pwd()} --build-arg buildNumber=${BUILD_NUMBER} --build-arg shortCommit=${env.SHORT_COMMIT} --build-arg commitAuthor=${env.COMMIT_AUTHOR} -d ${dockerReg}/${imageName}:${imageTag}
           """

--- a/vars/kanikoBuildPushGeneric.groovy
+++ b/vars/kanikoBuildPushGeneric.groovy
@@ -12,6 +12,7 @@ def call(String imageName, String imageTag = env.BUILD_NUMBER, String gcpProject
         withEnv(['PATH+EXTRA=/busybox:/kaniko']) {
           sh 'pwd'
           sh 'ls'
+          sh 'ls public'
           sh """#!/busybox/sh
             /kaniko/executor -f ${pwd()}/${dockerFile} -c ${pwd()} --build-arg buildNumber=${BUILD_NUMBER} --build-arg shortCommit=${env.SHORT_COMMIT} --build-arg commitAuthor=${env.COMMIT_AUTHOR} -d ${dockerReg}/${imageName}:${imageTag}
           """

--- a/vars/kanikoBuildPushGeneric.groovy
+++ b/vars/kanikoBuildPushGeneric.groovy
@@ -1,0 +1,20 @@
+// vars/kanikoBuildPush.groovy
+def call(String imageName, String imageTag = env.BUILD_NUMBER, String gcpProject = "core-workshop", String target = ".", String dockerFile="Dockerfile", Closure body) {
+  def dockerReg = "gcr.io/${gcpProject}"
+  def label = "kaniko-${UUID.randomUUID().toString()}"
+  def podYaml = libraryResource 'podtemplates/dockerBuildPush.yml'
+  podTemplate(name: 'kaniko', label: label, yaml: podYaml, nodeSelector: 'type=agent') {
+    node(label) {
+      body()
+      imageNameTag()
+      gitShortCommit()
+      container(name: 'kaniko', shell: '/busybox/sh') {
+        withEnv(['PATH+EXTRA=/busybox:/kaniko']) {
+          sh """#!/busybox/sh
+            /kaniko/executor -f ${pwd()}/${dockerFile} -c ${pwd()} --build-arg buildNumber=${BUILD_NUMBER} --build-arg shortCommit=${env.SHORT_COMMIT} --build-arg commitAuthor=${env.COMMIT_AUTHOR} -d ${dockerReg}/{imageName}:${BUILD_NUMBER}
+          """
+        }
+      }
+    }
+  }
+}

--- a/vars/kanikoBuildPushGeneric.groovy
+++ b/vars/kanikoBuildPushGeneric.groovy
@@ -11,7 +11,7 @@ def call(String imageName, String imageTag = env.BUILD_NUMBER, String gcpProject
       container(name: 'kaniko', shell: '/busybox/sh') {
         withEnv(['PATH+EXTRA=/busybox:/kaniko']) {
           sh """#!/busybox/sh
-            /kaniko/executor -f ${pwd()}/${dockerFile} -c ${pwd()} --build-arg buildNumber=${BUILD_NUMBER} --build-arg shortCommit=${env.SHORT_COMMIT} --build-arg commitAuthor=${env.COMMIT_AUTHOR} -d ${dockerReg}/${imageName}:${BUILD_NUMBER}
+            /kaniko/executor -f ${pwd()}/${dockerFile} -c ${pwd()} --build-arg buildNumber=${BUILD_NUMBER} --build-arg shortCommit=${env.SHORT_COMMIT} --build-arg commitAuthor=${env.COMMIT_AUTHOR} -d ${dockerReg}/${imageName}:${imageTag}
           """
         }
       }

--- a/vars/kanikoBuildPushGeneric.groovy
+++ b/vars/kanikoBuildPushGeneric.groovy
@@ -10,6 +10,7 @@ def call(String imageName, String imageTag = env.BUILD_NUMBER, String gcpProject
       gitShortCommit()
       container(name: 'kaniko', shell: '/busybox/sh') {
         withEnv(['PATH+EXTRA=/busybox:/kaniko']) {
+          echo "${imageName}"
           sh """#!/busybox/sh
             /kaniko/executor -f ${pwd()}/${dockerFile} -c ${pwd()} --build-arg buildNumber=${BUILD_NUMBER} --build-arg shortCommit=${env.SHORT_COMMIT} --build-arg commitAuthor=${env.COMMIT_AUTHOR} -d ${dockerReg}/${imageName}:${BUILD_NUMBER}
           """

--- a/vars/kanikoBuildPushGeneric.groovy
+++ b/vars/kanikoBuildPushGeneric.groovy
@@ -10,7 +10,6 @@ def call(String imageName, String imageTag = env.BUILD_NUMBER, String gcpProject
       gitShortCommit()
       container(name: 'kaniko', shell: '/busybox/sh') {
         withEnv(['PATH+EXTRA=/busybox:/kaniko']) {
-          echo "${imageName}"
           sh """#!/busybox/sh
             /kaniko/executor -f ${pwd()}/${dockerFile} -c ${pwd()} --build-arg buildNumber=${BUILD_NUMBER} --build-arg shortCommit=${env.SHORT_COMMIT} --build-arg commitAuthor=${env.COMMIT_AUTHOR} -d ${dockerReg}/${imageName}:${BUILD_NUMBER}
           """

--- a/vars/kanikoBuildPushGeneric.groovy
+++ b/vars/kanikoBuildPushGeneric.groovy
@@ -11,7 +11,7 @@ def call(String imageName, String imageTag = env.BUILD_NUMBER, String gcpProject
       container(name: 'kaniko', shell: '/busybox/sh') {
         withEnv(['PATH+EXTRA=/busybox:/kaniko']) {
           sh """#!/busybox/sh
-            /kaniko/executor -f ${pwd()}/${dockerFile} -c ${pwd()} --build-arg buildNumber=${BUILD_NUMBER} --build-arg shortCommit=${env.SHORT_COMMIT} --build-arg commitAuthor=${env.COMMIT_AUTHOR} -d ${dockerReg}/{imageName}:${BUILD_NUMBER}
+            /kaniko/executor -f ${pwd()}/${dockerFile} -c ${pwd()} --build-arg buildNumber=${BUILD_NUMBER} --build-arg shortCommit=${env.SHORT_COMMIT} --build-arg commitAuthor=${env.COMMIT_AUTHOR} -d ${dockerReg}/${imageName}:${BUILD_NUMBER}
           """
         }
       }

--- a/vars/kanikoBuildPushGeneric.groovy
+++ b/vars/kanikoBuildPushGeneric.groovy
@@ -10,9 +10,6 @@ def call(String imageName, String imageTag = env.BUILD_NUMBER, String gcpProject
       gitShortCommit()
       container(name: 'kaniko', shell: '/busybox/sh') {
         withEnv(['PATH+EXTRA=/busybox:/kaniko']) {
-          sh 'pwd'
-          sh 'ls'
-          sh 'ls public'
           sh """#!/busybox/sh
             /kaniko/executor -f ${pwd()}/${dockerFile} -c ${pwd()} --build-arg buildNumber=${BUILD_NUMBER} --build-arg shortCommit=${env.SHORT_COMMIT} --build-arg commitAuthor=${env.COMMIT_AUTHOR} -d ${dockerReg}/${imageName}:${imageTag}
           """


### PR DESCRIPTION
The kanikoBuildPushGeneric is just kanikoBuildPush without the hardcoded values. Really it makes sense to only have 1, but I know there are lots of pipelines out there using the existing one with the hardcoded values and I don't want to break all of that until we are able to go in and fix all of that.