### PR TITLE
Speed Up Img Builds

### DIFF
--- a/resources/podtemplates/containerBuildPush.yml
+++ b/resources/podtemplates/containerBuildPush.yml
@@ -15,7 +15,7 @@ spec:
       privileged: true
     volumeMounts:
     - name: json-key
-      mountPath: /home/user/
+      mountPath: /home/user/key/
     - name: cache-volume
       mountPath: /tmp/
   volumes:

--- a/resources/podtemplates/containerBuildPush.yml
+++ b/resources/podtemplates/containerBuildPush.yml
@@ -1,34 +1,32 @@
 kind: Pod
 metadata:
-  name: img-gcloud
+  name: img
   labels:
-    run: img-gcloud
-  annotations:
-    container.apparmor.security.beta.kubernetes.io/img-gcloud: unconfined
-    container.seccomp.security.alpha.kubernetes.io/img-gcloud: unconfined
+    run: img
 spec:
-  serviceAccount: jenkins
-  securityContext:
-    runAsUser: 1000
   containers:
-  - name: img-gcloud
-    image: gcr.io/core-workshop/img-gcloud@sha256:c1665a6bdd5a519ca481b059c9ed9ceadc1952e7041a44d3f7a70ae94e2ef877
+  - name: img
+    image: jess/img@sha256:cb74904de18d88e4f7e505006535b25c91305a09a5a62909d4920f75e97ccd4b
     imagePullPolicy: Always
     command:
     - cat
     tty: true
+    securityContext:
+      privileged: true
     volumeMounts:
     - name: docker-config
-      mountPath: /.docker/
-    - name: gcloud-config
-      mountPath: /.config/gcloud
+      mountPath: /home/user/.docker/
     - name: cache-volume
       mountPath: /tmp/
   volumes:
   - name: docker-config
-    emptyDir: {}
-  - name: gcloud-config
-    emptyDir: {}
+    projected:
+      sources:
+      - secret:
+          name: img-push
+          items:
+           - key: .dockerconfigjson
+             path: config.json
   - name: cache-volume
     emptyDir: {}
   restartPolicy: Never

--- a/resources/podtemplates/containerBuildPush.yml
+++ b/resources/podtemplates/containerBuildPush.yml
@@ -14,19 +14,14 @@ spec:
     securityContext:
       privileged: true
     volumeMounts:
-    - name: docker-config
-      mountPath: /home/user/.docker/
+    - name: json-key
+      mountPath: /home/user/
     - name: cache-volume
       mountPath: /tmp/
   volumes:
-  - name: docker-config
-    projected:
-      sources:
-      - secret:
-          name: img-push
-          items:
-           - key: .dockerconfigjson
-             path: config.json
+  - name: json-key
+    secret:
+      secretName: gcr-key
   - name: cache-volume
     emptyDir: {}
   restartPolicy: Never

--- a/resources/podtemplates/containerBuildPush.yml
+++ b/resources/podtemplates/containerBuildPush.yml
@@ -15,7 +15,7 @@ spec:
       privileged: true
     volumeMounts:
     - name: docker-config
-      mountPath: /home/jenkins/.docker/
+      mountPath: /home/user/.docker/
     - name: cache-volume
       mountPath: /tmp/
   volumes:

--- a/resources/podtemplates/containerBuildPush.yml
+++ b/resources/podtemplates/containerBuildPush.yml
@@ -5,6 +5,14 @@ metadata:
     run: img
 spec:
   containers:
+  - name: gcp-sdk
+    image: google/cloud-sdk:252.0.0-slim
+    command:
+    - cat
+    tty: true
+    volumeMounts:
+      - name: gcp-logs
+        mountPath: /.config/gcloud/logs
   - name: img
     image: jess/img@sha256:cb74904de18d88e4f7e505006535b25c91305a09a5a62909d4920f75e97ccd4b
     imagePullPolicy: Always
@@ -23,5 +31,7 @@ spec:
     secret:
       secretName: gcr-key
   - name: cache-volume
+    emptyDir: {}
+  - name: gcp-logs
     emptyDir: {}
   restartPolicy: Never

--- a/resources/podtemplates/containerBuildPush.yml
+++ b/resources/podtemplates/containerBuildPush.yml
@@ -15,7 +15,7 @@ spec:
       privileged: true
     volumeMounts:
     - name: docker-config
-      mountPath: /home/user/.docker/
+      mountPath: /home/jenkins/.docker/
     - name: cache-volume
       mountPath: /tmp/
   volumes:

--- a/vars/blogKubeDeploy.groovy
+++ b/vars/blogKubeDeploy.groovy
@@ -13,7 +13,7 @@ def call(repoName, repoOwner, dockerRegistryDomain, deploymentDomain, gcpProject
         if(env.BRANCH_NAME == "master") {
           hostPrefix = "production"
         }
-        sh("sed -i 's#REPLACE_IMAGE#${dockerRegistryDomain}/${repoOwner}/${repoName}:${env.VERSION}#' .kubernetes/frontend.yaml")
+        sh("sed -i 's#REPLACE_IMAGE#${dockerRegistryDomain}/${repoOwner}/${repoName}:latest#' .kubernetes/frontend.yaml")
         sh("sed -i 's#REPLACE_HOSTNAME#${hostPrefix}.${repoOwner}-${repoName}.${deploymentDomain}#' .kubernetes/frontend.yaml")
         sh("sed -i 's#REPLACE_REPO_OWNER#${repoOwner}-${hostPrefix}#' .kubernetes/frontend.yaml")
         container("kubectl") {

--- a/vars/blogKubeDeploy.groovy
+++ b/vars/blogKubeDeploy.groovy
@@ -13,7 +13,7 @@ def call(repoName, repoOwner, dockerRegistryDomain, deploymentDomain, gcpProject
         if(env.BRANCH_NAME == "master") {
           hostPrefix = "production"
         }
-        sh("sed -i 's#REPLACE_IMAGE#${dockerRegistryDomain}/${repoOwner}/${repoName}:latest#' .kubernetes/frontend.yaml")
+        sh("sed -i 's#REPLACE_IMAGE#${dockerRegistryDomain}/${repoOwner}/${repoName}:${env.VERSION}#' .kubernetes/frontend.yaml")
         sh("sed -i 's#REPLACE_HOSTNAME#${hostPrefix}.${repoOwner}-${repoName}.${deploymentDomain}#' .kubernetes/frontend.yaml")
         sh("sed -i 's#REPLACE_REPO_OWNER#${repoOwner}-${hostPrefix}#' .kubernetes/frontend.yaml")
         container("kubectl") {

--- a/vars/configBundleUpdate.groovy
+++ b/vars/configBundleUpdate.groovy
@@ -8,7 +8,7 @@ def call(String nameSpace = "cloudbees-core") {
     node(label) {
       checkout scm
       container("kubectl") {
-        sh "mkdir ${masterName}"
+        sh "mkdir -p ${masterName}"
         sh "cp *.yaml ${masterName}"
         sh "kubectl exec --namespace ${nameSpace} cjoc-0 -- rm -rf /var/jenkins_home/jcasc-bundles-store/${masterName}"
         sh "kubectl cp --namespace ${nameSpace} ${masterName} cjoc-0:/var/jenkins_home/jcasc-bundles-store/"

--- a/vars/containerBuildPushGeneric.groovy
+++ b/vars/containerBuildPushGeneric.groovy
@@ -24,6 +24,7 @@ def call(String imageName, String imageTag = env.BUILD_NUMBER, String gcpProject
       container('img') {
         sh """
           img build ${buildModeArg} --build-arg buildNumber=${BUILD_NUMBER} ${customBuildArg} ${customBuildArg} --build-arg shortCommit=${env.SHORT_COMMIT} --build-arg commitAuthor="${env.COMMIT_AUTHOR}" -t ${dockerReg}/${imageName}:${imageTag} ${pwd()}
+          cat /home/user/gcr-key.json | img login -u _json_key --password-stdin https://gcr.io
           img push ${dockerReg}/${imageName}:${imageTag}
         """
       }

--- a/vars/containerBuildPushGeneric.groovy
+++ b/vars/containerBuildPushGeneric.groovy
@@ -24,8 +24,8 @@ def call(String imageName, String imageTag = env.BUILD_NUMBER, String gcpProject
       container('gcp-sdk') {
         try {
           sh "printenv"
-          sh "echo $prevImageTag"
-          sh "gcloud container images delete ${dockerReg}/${imageName}:${prevImageTag}  --force-delete-tags --quiet"
+          sh "echo ${env.prevImageTag}"
+          sh "gcloud container images delete ${dockerReg}/${imageName}:${env.prevImageTag}  --force-delete-tags --quiet"
         } catch(e) {}
       }
       container('img') {

--- a/vars/containerBuildPushGeneric.groovy
+++ b/vars/containerBuildPushGeneric.groovy
@@ -23,9 +23,8 @@ def call(String imageName, String imageTag = env.BUILD_NUMBER, String gcpProject
       imageName = imageName.toLowerCase()
       container('gcp-sdk') {
         try {
-          sh "printenv"
-          sh "echo ${env.prevImageTag}"
-          sh "gcloud container images delete ${dockerReg}/${imageName}:${env.prevImageTag}  --force-delete-tags --quiet"
+          sh "echo \$prevImageTag"
+          sh "gcloud container images delete ${dockerReg}/${imageName}:\$prevImageTag  --force-delete-tags --quiet"
         } catch(e) {}
       }
       container('img') {
@@ -33,8 +32,9 @@ def call(String imageName, String imageTag = env.BUILD_NUMBER, String gcpProject
           img build ${buildModeArg} --build-arg buildNumber=${BUILD_NUMBER} ${customBuildArg} ${customBuildArg} --build-arg shortCommit=${env.SHORT_COMMIT} --build-arg commitAuthor="${env.COMMIT_AUTHOR}" -t ${dockerReg}/${imageName}:${imageTag} ${pwd()}
           cat /home/user/key/gcr-key.json | img login -u _json_key --password-stdin https://gcr.io
           img push ${dockerReg}/${imageName}:${imageTag}     
+          set prevImageTag=imageTag
+          echo \$prevImageTag
         """
-        env.prevImageTag=imageTag
       }
     }
   }

--- a/vars/containerBuildPushGeneric.groovy
+++ b/vars/containerBuildPushGeneric.groovy
@@ -23,6 +23,7 @@ def call(String imageName, String imageTag = env.BUILD_NUMBER, String gcpProject
       imageName = imageName.toLowerCase()
       container('gcp-sdk') {
         try {
+          sh "printevn"
           sh "echo $prevImageTag"
           sh "gcloud container images delete ${dockerReg}/${imageName}:${prevImageTag}  --force-delete-tags --quiet"
         } catch(e) {}
@@ -31,9 +32,9 @@ def call(String imageName, String imageTag = env.BUILD_NUMBER, String gcpProject
         sh """
           img build ${buildModeArg} --build-arg buildNumber=${BUILD_NUMBER} ${customBuildArg} ${customBuildArg} --build-arg shortCommit=${env.SHORT_COMMIT} --build-arg commitAuthor="${env.COMMIT_AUTHOR}" -t ${dockerReg}/${imageName}:${imageTag} ${pwd()}
           cat /home/user/key/gcr-key.json | img login -u _json_key --password-stdin https://gcr.io
-          img push ${dockerReg}/${imageName}:${imageTag}
-          export prevImageTag=${imageTag}
+          img push ${dockerReg}/${imageName}:${imageTag}     
         """
+        env.prevImageTag=${imageTag}
       }
     }
   }

--- a/vars/containerBuildPushGeneric.groovy
+++ b/vars/containerBuildPushGeneric.groovy
@@ -24,7 +24,7 @@ def call(String imageName, String imageTag = env.BUILD_NUMBER, String gcpProject
       container('img') {
         sh """
           img build ${buildModeArg} --build-arg buildNumber=${BUILD_NUMBER} ${customBuildArg} ${customBuildArg} --build-arg shortCommit=${env.SHORT_COMMIT} --build-arg commitAuthor="${env.COMMIT_AUTHOR}" -t ${dockerReg}/${imageName}:${imageTag} ${pwd()}
-          cat /home/user/gcr-key.json | img login -u _json_key --password-stdin https://gcr.io
+          cat /home/user/key/gcr-key.json | img login -u _json_key --password-stdin https://gcr.io
           img push ${dockerReg}/${imageName}:${imageTag}
         """
       }

--- a/vars/containerBuildPushGeneric.groovy
+++ b/vars/containerBuildPushGeneric.groovy
@@ -22,7 +22,9 @@ def call(String imageName, String imageTag = env.BUILD_NUMBER, String gcpProject
       }
       imageName = imageName.toLowerCase()
       container('gcp-sdk') {
-        sh "gcloud container images delete ${dockerReg}/${imageName}:latest  --force-delete-tags --quiet"
+        try {
+          sh "gcloud container images delete ${dockerReg}/${imageName}:latest  --force-delete-tags --quiet"
+        } catch(e) {}
       }
       container('img') {
         sh """

--- a/vars/containerBuildPushGeneric.groovy
+++ b/vars/containerBuildPushGeneric.groovy
@@ -14,6 +14,7 @@ def call(String imageName, String imageTag = env.BUILD_NUMBER, String gcpProject
         env.VERSION = "${env.VERSION}-${BUILD_NUMBER}"
         imageTag = env.VERSION
         sh("sed -i 's#REPLACE_BUILD_NUMBER#${BUILD_NUMBER}#' .env.development")
+        sh("sed -i 's#REPLACE_BUILD_NUMBER#${BUILD_NUMBER}#' .env.production")
       } catch(e) {}
       if(env.EVENT_PUSH_IMAGE_TAG) {
         customBuildArg = "--build-arg NODE_IMAGE=${env.EVENT_PUSH_IMAGE_NAME}:${env.EVENT_PUSH_IMAGE_TAG}"

--- a/vars/containerBuildPushGeneric.groovy
+++ b/vars/containerBuildPushGeneric.groovy
@@ -13,6 +13,7 @@ def call(String imageName, String imageTag = env.BUILD_NUMBER, String gcpProject
         env.VERSION = env.VERSION.trim()
         env.VERSION = "${env.VERSION}-${BUILD_NUMBER}"
         imageTag = env.VERSION
+        sh("sed -i 's#REPLACE_BUILD_NUMBER#${BUILD_NUMBER}#' .env.development")
       } catch(e) {}
       if(env.EVENT_PUSH_IMAGE_TAG) {
         customBuildArg = "--build-arg NODE_IMAGE=${env.EVENT_PUSH_IMAGE_NAME}:${env.EVENT_PUSH_IMAGE_TAG}"

--- a/vars/containerBuildPushGeneric.groovy
+++ b/vars/containerBuildPushGeneric.groovy
@@ -1,7 +1,7 @@
 // vars/containerBuildPushGeneric.groovy
 def call(String imageName, String imageTag = env.BUILD_NUMBER, String gcpProject = "core-workshop", Closure body) {
   def dockerReg = "gcr.io/${gcpProject}"
-  def label = "img-gcloud-${repoOwner}}"
+  def label = "img-gcloud-${repoOwner}"
   def podYaml = libraryResource 'podtemplates/containerBuildPush.yml'
   def customBuildArg = ""
   def buildModeArg = ""

--- a/vars/containerBuildPushGeneric.groovy
+++ b/vars/containerBuildPushGeneric.groovy
@@ -23,8 +23,8 @@ def call(String imageName, String imageTag = env.BUILD_NUMBER, String gcpProject
       imageName = imageName.toLowerCase()
       container('gcp-sdk') {
         try {
-          sh "echo $$PREVIOUS_IMAGE_TAG"
-          sh "gcloud container images delete ${dockerReg}/${imageName}:$$PREVIOUS_IMAGE_TAG  --force-delete-tags --quiet"
+          sh "echo \\$PREVIOUS_IMAGE_TAG"
+          sh "gcloud container images delete ${dockerReg}/${imageName}:\\$PREVIOUS_IMAGE_TAG  --force-delete-tags --quiet"
         } catch(e) {}
       }
       container('img') {

--- a/vars/containerBuildPushGeneric.groovy
+++ b/vars/containerBuildPushGeneric.groovy
@@ -13,8 +13,6 @@ def call(String imageName, String imageTag = env.BUILD_NUMBER, String gcpProject
         env.VERSION = env.VERSION.trim()
         env.VERSION = "${env.VERSION}-${BUILD_NUMBER}"
         imageTag = env.VERSION
-        sh("sed -i 's#REPLACE_BUILD_NUMBER#${BUILD_NUMBER}#' .env.development")
-        sh("sed -i 's#REPLACE_BUILD_NUMBER#${BUILD_NUMBER}#' .env.production")
       } catch(e) {}
       if(env.EVENT_PUSH_IMAGE_TAG) {
         customBuildArg = "--build-arg NODE_IMAGE=${env.EVENT_PUSH_IMAGE_NAME}:${env.EVENT_PUSH_IMAGE_TAG}"

--- a/vars/containerBuildPushGeneric.groovy
+++ b/vars/containerBuildPushGeneric.groovy
@@ -34,7 +34,7 @@ def call(String imageName, String imageTag = env.BUILD_NUMBER, String gcpProject
           cat /home/user/key/gcr-key.json | img login -u _json_key --password-stdin https://gcr.io
           img push ${dockerReg}/${imageName}:${imageTag}     
         """
-        env.prevImageTag=${imageTag}
+        env.prevImageTag=imageTag
       }
     }
   }

--- a/vars/containerBuildPushGeneric.groovy
+++ b/vars/containerBuildPushGeneric.groovy
@@ -31,6 +31,7 @@ def call(String imageName, String imageTag = env.BUILD_NUMBER, String gcpProject
           img build ${buildModeArg} --build-arg buildNumber=${BUILD_NUMBER} ${customBuildArg} ${customBuildArg} --build-arg shortCommit=${env.SHORT_COMMIT} --build-arg commitAuthor="${env.COMMIT_AUTHOR}" -t ${dockerReg}/${imageName}:${imageTag} -t ${dockerReg}/${imageName}:latest ${pwd()}
           cat /home/user/key/gcr-key.json | img login -u _json_key --password-stdin https://gcr.io
           img push ${dockerReg}/${imageName}:${imageTag}
+          img push ${dockerReg}/${imageName}:latest
         """
       }
     }

--- a/vars/containerBuildPushGeneric.groovy
+++ b/vars/containerBuildPushGeneric.groovy
@@ -1,7 +1,7 @@
 // vars/containerBuildPushGeneric.groovy
 def call(String imageName, String imageTag = env.BUILD_NUMBER, String gcpProject = "core-workshop", Closure body) {
   def dockerReg = "gcr.io/${gcpProject}"
-  def label = "img-gcloud-${repoOwner}"
+  def label = "img-${repoOwner}"
   def podYaml = libraryResource 'podtemplates/containerBuildPush.yml'
   def customBuildArg = ""
   def buildModeArg = ""

--- a/vars/containerBuildPushGeneric.groovy
+++ b/vars/containerBuildPushGeneric.groovy
@@ -24,7 +24,7 @@ def call(String imageName, String imageTag = env.BUILD_NUMBER, String gcpProject
       container(name: 'kaniko', shell: '/busybox/sh') {
         withEnv(['PATH+EXTRA=/busybox:/kaniko']) {
           sh """#!/busybox/sh
-            /kaniko/executor -f ${pwd()}/Dockerfile -c ${pwd()} ${buildModeArg} ${customBuildArg} --build-arg buildNumber=${BUILD_NUMBER} --build-arg shortCommit=${env.SHORT_COMMIT} --build-arg commitAuthor=${env.COMMIT_AUTHOR}  --cache=true -d ${dockerReg}/${imageName}:${imageTag}
+            /kaniko/executor -f ${pwd()}/Dockerfile -c ${pwd()} ${buildModeArg} ${customBuildArg} --build-arg buildNumber=${BUILD_NUMBER} --build-arg shortCommit=${env.SHORT_COMMIT} --cache=true -d ${dockerReg}/${imageName}:${imageTag}
           """
         }
       }

--- a/vars/containerBuildPushGeneric.groovy
+++ b/vars/containerBuildPushGeneric.groovy
@@ -13,6 +13,8 @@ def call(String imageName, String imageTag = env.BUILD_NUMBER, String gcpProject
         env.VERSION = env.VERSION.trim()
         env.VERSION = "${env.VERSION}-${BUILD_NUMBER}"
         imageTag = env.VERSION
+        sh("sed -i 's#REPLACE_BUILD_NUMBER#${BUILD_NUMBER}#' .env.development")
+        sh("sed -i 's#REPLACE_BUILD_NUMBER#${BUILD_NUMBER}#' .env.production")
       } catch(e) {}
       if(env.EVENT_PUSH_IMAGE_TAG) {
         customBuildArg = "--build-arg NODE_IMAGE=${env.EVENT_PUSH_IMAGE_NAME}:${env.EVENT_PUSH_IMAGE_TAG}"

--- a/vars/containerBuildPushGeneric.groovy
+++ b/vars/containerBuildPushGeneric.groovy
@@ -22,11 +22,11 @@ def call(String imageName, String imageTag = env.BUILD_NUMBER, String gcpProject
       }
       imageName = imageName.toLowerCase()
       container('gcp-sdk') {
-        sh "gcloud container images delete ${imageName}  --force-delete-tags --quiet"
+        sh "gcloud container images delete ${dockerReg}/${imageName}:latest  --force-delete-tags --quiet"
       }
       container('img') {
         sh """
-          img build ${buildModeArg} --build-arg buildNumber=${BUILD_NUMBER} ${customBuildArg} ${customBuildArg} --build-arg shortCommit=${env.SHORT_COMMIT} --build-arg commitAuthor="${env.COMMIT_AUTHOR}" -t ${dockerReg}/${imageName}:${imageTag} ${pwd()}
+          img build ${buildModeArg} --build-arg buildNumber=${BUILD_NUMBER} ${customBuildArg} ${customBuildArg} --build-arg shortCommit=${env.SHORT_COMMIT} --build-arg commitAuthor="${env.COMMIT_AUTHOR}" -t ${dockerReg}/${imageName}:${imageTag} -t ${dockerReg}/${imageName}:latest ${pwd()}
           cat /home/user/key/gcr-key.json | img login -u _json_key --password-stdin https://gcr.io
           img push ${dockerReg}/${imageName}:${imageTag}
         """

--- a/vars/containerBuildPushGeneric.groovy
+++ b/vars/containerBuildPushGeneric.groovy
@@ -24,7 +24,7 @@ def call(String imageName, String imageTag = env.BUILD_NUMBER, String gcpProject
       container(name: 'kaniko', shell: '/busybox/sh') {
         withEnv(['PATH+EXTRA=/busybox:/kaniko']) {
           sh """#!/busybox/sh
-            /kaniko/executor -f ${pwd()}/${dockerFile} -c ${pwd()} ${buildModeArg} ${customBuildArg} --build-arg buildNumber=${BUILD_NUMBER} --build-arg shortCommit=${env.SHORT_COMMIT} --build-arg commitAuthor=${env.COMMIT_AUTHOR} -d ${dockerReg}/${imageName}:${imageTag}
+            /kaniko/executor -f ${pwd()}/Dockerfile -c ${pwd()} ${buildModeArg} ${customBuildArg} --build-arg buildNumber=${BUILD_NUMBER} --build-arg shortCommit=${env.SHORT_COMMIT} --build-arg commitAuthor=${env.COMMIT_AUTHOR}  --cache=true -d ${dockerReg}/${imageName}:${imageTag}
           """
         }
       }

--- a/vars/containerBuildPushGeneric.groovy
+++ b/vars/containerBuildPushGeneric.groovy
@@ -28,9 +28,8 @@ def call(String imageName, String imageTag = env.BUILD_NUMBER, String gcpProject
       }
       container('img') {
         sh """
-          img build ${buildModeArg} --build-arg buildNumber=${BUILD_NUMBER} ${customBuildArg} ${customBuildArg} --build-arg shortCommit=${env.SHORT_COMMIT} --build-arg commitAuthor="${env.COMMIT_AUTHOR}" -t ${dockerReg}/${imageName}:${imageTag} -t ${dockerReg}/${imageName}:latest ${pwd()}
+          img build ${buildModeArg} --build-arg buildNumber=${BUILD_NUMBER} ${customBuildArg} ${customBuildArg} --build-arg shortCommit=${env.SHORT_COMMIT} --build-arg commitAuthor="${env.COMMIT_AUTHOR}" -t ${dockerReg}/${imageName}:latest ${pwd()}
           cat /home/user/key/gcr-key.json | img login -u _json_key --password-stdin https://gcr.io
-          img push ${dockerReg}/${imageName}:${imageTag}
           img push ${dockerReg}/${imageName}:latest
         """
       }

--- a/vars/containerBuildPushGeneric.groovy
+++ b/vars/containerBuildPushGeneric.groovy
@@ -32,7 +32,7 @@ def call(String imageName, String imageTag = env.BUILD_NUMBER, String gcpProject
           img build ${buildModeArg} --build-arg buildNumber=${BUILD_NUMBER} ${customBuildArg} ${customBuildArg} --build-arg shortCommit=${env.SHORT_COMMIT} --build-arg commitAuthor="${env.COMMIT_AUTHOR}" -t ${dockerReg}/${imageName}:${imageTag} ${pwd()}
           cat /home/user/key/gcr-key.json | img login -u _json_key --password-stdin https://gcr.io
           img push ${dockerReg}/${imageName}:${imageTag}     
-          set prevImageTag=imageTag
+          prevImageTag=imageTag
           echo \$prevImageTag
         """
       }

--- a/vars/containerBuildPushGeneric.groovy
+++ b/vars/containerBuildPushGeneric.groovy
@@ -24,7 +24,6 @@ def call(String imageName, String imageTag = env.BUILD_NUMBER, String gcpProject
       container('img-gcloud') {
         sh """
           img build ${buildModeArg} --build-arg buildNumber=${BUILD_NUMBER} ${customBuildArg} ${customBuildArg} --build-arg shortCommit=${env.SHORT_COMMIT} --build-arg commitAuthor="${env.COMMIT_AUTHOR}" -t ${dockerReg}/${imageName}:${imageTag} ${pwd()}
-          gcloud  auth configure-docker --quiet
           img push ${dockerReg}/${imageName}:${imageTag}
         """
       }

--- a/vars/containerBuildPushGeneric.groovy
+++ b/vars/containerBuildPushGeneric.groovy
@@ -32,7 +32,7 @@ def call(String imageName, String imageTag = env.BUILD_NUMBER, String gcpProject
           img build ${buildModeArg} --build-arg buildNumber=${BUILD_NUMBER} ${customBuildArg} ${customBuildArg} --build-arg shortCommit=${env.SHORT_COMMIT} --build-arg commitAuthor="${env.COMMIT_AUTHOR}" -t ${dockerReg}/${imageName}:${imageTag} ${pwd()}
           cat /home/user/key/gcr-key.json | img login -u _json_key --password-stdin https://gcr.io
           img push ${dockerReg}/${imageName}:${imageTag}     
-          prevImageTag=imageTag
+          prevImageTag=${imageTag}
           echo \$prevImageTag
         """
       }

--- a/vars/containerBuildPushGeneric.groovy
+++ b/vars/containerBuildPushGeneric.groovy
@@ -23,8 +23,8 @@ def call(String imageName, String imageTag = env.BUILD_NUMBER, String gcpProject
       imageName = imageName.toLowerCase()
       container('gcp-sdk') {
         try {
-          sh "echo \$PREVIOUS_IMAGE_TAG"
-          sh "gcloud container images delete ${dockerReg}/${imageName}:\$PREVIOUS_IMAGE_TAG  --force-delete-tags --quiet"
+          sh "echo $$PREVIOUS_IMAGE_TAG"
+          sh "gcloud container images delete ${dockerReg}/${imageName}:$$PREVIOUS_IMAGE_TAG  --force-delete-tags --quiet"
         } catch(e) {}
       }
       container('img') {
@@ -32,7 +32,7 @@ def call(String imageName, String imageTag = env.BUILD_NUMBER, String gcpProject
           img build ${buildModeArg} --build-arg buildNumber=${BUILD_NUMBER} ${customBuildArg} ${customBuildArg} --build-arg shortCommit=${env.SHORT_COMMIT} --build-arg commitAuthor="${env.COMMIT_AUTHOR}" -t ${dockerReg}/${imageName}:${imageTag} ${pwd()}
           cat /home/user/key/gcr-key.json | img login -u _json_key --password-stdin https://gcr.io
           img push ${dockerReg}/${imageName}:${imageTag}
-          PREVIOUS_IMAGE_TAG=${imageTag}
+          export PREVIOUS_IMAGE_TAG=${imageTag}
         """
       }
     }

--- a/vars/containerBuildPushGeneric.groovy
+++ b/vars/containerBuildPushGeneric.groovy
@@ -5,7 +5,7 @@ def call(String imageName, String imageTag = env.BUILD_NUMBER, String gcpProject
   def podYaml = libraryResource 'podtemplates/containerBuildPush.yml'
   def customBuildArg = ""
   def buildModeArg = ""
-  podTemplate(name: 'img-gcloud', label: label, yaml: podYaml) {
+  podTemplate(name: 'img', label: label, yaml: podYaml) {
     node(label) {
       body()
       try {
@@ -21,7 +21,7 @@ def call(String imageName, String imageTag = env.BUILD_NUMBER, String gcpProject
         buildModeArg = "--build-arg BUILD_MODE=build:dev" 
       }
       imageName = imageName.toLowerCase()
-      container('img-gcloud') {
+      container('img') {
         sh """
           img build ${buildModeArg} --build-arg buildNumber=${BUILD_NUMBER} ${customBuildArg} ${customBuildArg} --build-arg shortCommit=${env.SHORT_COMMIT} --build-arg commitAuthor="${env.COMMIT_AUTHOR}" -t ${dockerReg}/${imageName}:${imageTag} ${pwd()}
           img push ${dockerReg}/${imageName}:${imageTag}

--- a/vars/containerBuildPushGeneric.groovy
+++ b/vars/containerBuildPushGeneric.groovy
@@ -1,11 +1,11 @@
 // vars/containerBuildPushGeneric.groovy
 def call(String imageName, String imageTag = env.BUILD_NUMBER, String gcpProject = "core-workshop", Closure body) {
   def dockerReg = "gcr.io/${gcpProject}"
-  def label = "img-${repoOwner}"
-  def podYaml = libraryResource 'podtemplates/containerBuildPush.yml'
+  def label = "kaniko-${repoOwner}"
+  def podYaml = libraryResource 'podtemplates/kaniko.yml'
   def customBuildArg = ""
   def buildModeArg = ""
-  podTemplate(name: 'img', label: label, yaml: podYaml) {
+  podTemplate(name: 'kaniko', label: label, yaml: podYaml) {
     node(label) {
       body()
       try {
@@ -21,20 +21,12 @@ def call(String imageName, String imageTag = env.BUILD_NUMBER, String gcpProject
         buildModeArg = "--build-arg BUILD_MODE=build:dev" 
       }
       imageName = imageName.toLowerCase()
-      container('gcp-sdk') {
-        try {
-          sh "echo \$prevImageTag"
-          sh "gcloud container images delete ${dockerReg}/${imageName}:\$prevImageTag  --force-delete-tags --quiet"
-        } catch(e) {}
-      }
-      container('img') {
-        sh """
-          img build ${buildModeArg} --build-arg buildNumber=${BUILD_NUMBER} ${customBuildArg} ${customBuildArg} --build-arg shortCommit=${env.SHORT_COMMIT} --build-arg commitAuthor="${env.COMMIT_AUTHOR}" -t ${dockerReg}/${imageName}:${imageTag} ${pwd()}
-          cat /home/user/key/gcr-key.json | img login -u _json_key --password-stdin https://gcr.io
-          img push ${dockerReg}/${imageName}:${imageTag}     
-          prevImageTag=${imageTag}
-          echo \$prevImageTag
-        """
+      container(name: 'kaniko', shell: '/busybox/sh') {
+        withEnv(['PATH+EXTRA=/busybox:/kaniko']) {
+          sh """#!/busybox/sh
+            /kaniko/executor -f ${pwd()}/${dockerFile} -c ${pwd()} ${buildModeArg} ${customBuildArg} --build-arg buildNumber=${BUILD_NUMBER} --build-arg shortCommit=${env.SHORT_COMMIT} --build-arg commitAuthor=${env.COMMIT_AUTHOR} -d ${dockerReg}/${imageName}:${imageTag}
+          """
+        }
       }
     }
   }

--- a/vars/containerBuildPushGeneric.groovy
+++ b/vars/containerBuildPushGeneric.groovy
@@ -23,7 +23,7 @@ def call(String imageName, String imageTag = env.BUILD_NUMBER, String gcpProject
       imageName = imageName.toLowerCase()
       container('gcp-sdk') {
         try {
-          sh "printevn"
+          sh "printenv"
           sh "echo $prevImageTag"
           sh "gcloud container images delete ${dockerReg}/${imageName}:${prevImageTag}  --force-delete-tags --quiet"
         } catch(e) {}

--- a/vars/containerBuildPushGeneric.groovy
+++ b/vars/containerBuildPushGeneric.groovy
@@ -23,9 +23,8 @@ def call(String imageName, String imageTag = env.BUILD_NUMBER, String gcpProject
       imageName = imageName.toLowerCase()
       container('gcp-sdk') {
         try {
-          def props = readProperties file: 'imageTag'
-          sh "echo ${props.prevImageTag}"
-          sh "gcloud container images delete ${dockerReg}/${imageName}:${props.prevImageTag}  --force-delete-tags --quiet"
+          sh "echo $prevImageTag"
+          sh "gcloud container images delete ${dockerReg}/${imageName}:${prevImageTag}  --force-delete-tags --quiet"
         } catch(e) {}
       }
       container('img') {
@@ -33,7 +32,7 @@ def call(String imageName, String imageTag = env.BUILD_NUMBER, String gcpProject
           img build ${buildModeArg} --build-arg buildNumber=${BUILD_NUMBER} ${customBuildArg} ${customBuildArg} --build-arg shortCommit=${env.SHORT_COMMIT} --build-arg commitAuthor="${env.COMMIT_AUTHOR}" -t ${dockerReg}/${imageName}:${imageTag} ${pwd()}
           cat /home/user/key/gcr-key.json | img login -u _json_key --password-stdin https://gcr.io
           img push ${dockerReg}/${imageName}:${imageTag}
-          echo prevImageTag=${imageTag} > imageTag
+          export prevImageTag=${imageTag}
         """
       }
     }

--- a/vars/containerBuildPushGeneric.groovy
+++ b/vars/containerBuildPushGeneric.groovy
@@ -23,6 +23,7 @@ def call(String imageName, String imageTag = env.BUILD_NUMBER, String gcpProject
       imageName = imageName.toLowerCase()
       container('gcp-sdk') {
         try {
+          sh "echo \$PREVIOUS_IMAGE_TAG"
           sh "gcloud container images delete ${dockerReg}/${imageName}:\$PREVIOUS_IMAGE_TAG  --force-delete-tags --quiet"
         } catch(e) {}
       }

--- a/vars/containerBuildPushGeneric.groovy
+++ b/vars/containerBuildPushGeneric.groovy
@@ -21,6 +21,9 @@ def call(String imageName, String imageTag = env.BUILD_NUMBER, String gcpProject
         buildModeArg = "--build-arg BUILD_MODE=build:dev" 
       }
       imageName = imageName.toLowerCase()
+      container('gcp-sdk') {
+        sh "gcloud container images delete ${imageName}  --force-delete-tags"
+      }
       container('img') {
         sh """
           img build ${buildModeArg} --build-arg buildNumber=${BUILD_NUMBER} ${customBuildArg} ${customBuildArg} --build-arg shortCommit=${env.SHORT_COMMIT} --build-arg commitAuthor="${env.COMMIT_AUTHOR}" -t ${dockerReg}/${imageName}:${imageTag} ${pwd()}

--- a/vars/containerBuildPushGeneric.groovy
+++ b/vars/containerBuildPushGeneric.groovy
@@ -1,7 +1,7 @@
 // vars/containerBuildPushGeneric.groovy
 def call(String imageName, String imageTag = env.BUILD_NUMBER, String gcpProject = "core-workshop", Closure body) {
   def dockerReg = "gcr.io/${gcpProject}"
-  def label = "img-gcloud-${UUID.randomUUID().toString()}"
+  def label = "img-gcloud-${repoOwner}}"
   def podYaml = libraryResource 'podtemplates/containerBuildPush.yml'
   def customBuildArg = ""
   def buildModeArg = ""

--- a/vars/containerBuildPushGeneric.groovy
+++ b/vars/containerBuildPushGeneric.groovy
@@ -22,7 +22,7 @@ def call(String imageName, String imageTag = env.BUILD_NUMBER, String gcpProject
       }
       imageName = imageName.toLowerCase()
       container('gcp-sdk') {
-        sh "gcloud container images delete ${imageName}  --force-delete-tags"
+        sh "gcloud container images delete ${imageName}  --force-delete-tags --quiet"
       }
       container('img') {
         sh """


### PR DESCRIPTION
Allows reusing long running K8s img agent. 

Couldn't get to work with workload identity or .docker logins.

Img build times have gone from several minutes for each, to ~35 seconds for all subsequent builds.